### PR TITLE
fix(logs): make structured logs Railway-compatible

### DIFF
--- a/logs/logs.go
+++ b/logs/logs.go
@@ -1,5 +1,5 @@
-// Log in JSON format for cloudwatch
-// All level entries are the same except for Debug
+// Log in single-line JSON, for CloudWatch and Railway structured-log parsing alike.
+// Print is the exception — dev-only, pretty-printed for terminal readability.
 // Level will be used for different parameters
 package logs
 
@@ -40,11 +40,17 @@ type logEntry struct {
 	Request  any    `json:"request,omitempty"`
 	Function string `json:"function,omitempty"`
 	AppEnv   string `json:"app_env,omitempty"`
-	Note     string `json:"note"`
+	Service  string `json:"service,omitempty"`
+	Message  string `json:"message"`
 	Data     any    `json:"data,omitempty"`
 }
 
 var Request any
+
+// Service identifies which upstream microservice is logging, since booky-ark
+// bundles many microservices' handlers into one process. Set by the caller
+// (e.g. booky-ark's apigwadapter/eventadapter) before invoking a handler.
+var Service string
 
 // Production-only debugging. Suppressed outside production (APP_ENV != production).
 // Use for targeted diagnostics when investigating a live issue.
@@ -97,10 +103,10 @@ func Fatal(note string, data ...any) {
 	logIt(FATAL, note, data...)
 }
 
-func logIt(level Level, note string, data ...any) {
+func logIt(level Level, message string, data ...any) {
 	le := logEntry{
-		Level: level,
-		Note:  note,
+		Level:   level,
+		Message: message,
 	}
 
 	if len(data) > 0 {
@@ -111,6 +117,7 @@ func logIt(level Level, note string, data ...any) {
 		le.Request = Request
 		le.Function = os.Getenv("AWS_LAMBDA_FUNCTION_NAME")
 		le.AppEnv = os.Getenv("APP_ENV")
+		le.Service = Service
 	}
 
 	l, err := jsonMarshal(le)
@@ -147,8 +154,12 @@ func logIt(level Level, note string, data ...any) {
 	wg.Wait()
 }
 
+// Print is dev-only console output — pretty-printed for terminal readability.
+// It never runs in production, so it never reaches Railway/CloudWatch. Every
+// other level ships single-line JSON so line-oriented log collectors can
+// parse one entry per line.
 func jsonMarshal(le logEntry) ([]byte, error) {
-	if le.Level == DEBUG || le.Level == PRINT {
+	if le.Level == PRINT {
 		return json.MarshalIndent(le, "", "  ")
 	}
 

--- a/logs/logs_test.go
+++ b/logs/logs_test.go
@@ -1,0 +1,150 @@
+package logs
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log"
+	"os"
+	"strings"
+	"testing"
+)
+
+// captureOutput redirects both os.Stdout and the log package's output to a
+// pipe for the duration of fn, then returns the captured output split into
+// individual lines (log.Print always appends its own trailing newline).
+func captureOutput(t *testing.T, fn func()) []string {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+
+	origStdout := os.Stdout
+	os.Stdout = w
+	log.SetOutput(w)
+
+	fn()
+
+	w.Close()
+	os.Stdout = origStdout
+	log.SetOutput(os.Stdout)
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("io.Copy: %v", err)
+	}
+
+	trimmed := strings.TrimRight(buf.String(), "\n")
+	if trimmed == "" {
+		return nil
+	}
+
+	return strings.Split(trimmed, "\n")
+}
+
+// Railway (and any line-oriented log collector) requires one JSON object per
+// line. Debug used to be pretty-printed via json.MarshalIndent, which split a
+// single log entry across many lines and broke level-based filtering.
+func TestLogIt_EmitsSingleLineJSON(t *testing.T) {
+	t.Setenv("APP_ENV", PRODUCTION_ENV)
+
+	for _, level := range []struct {
+		name string
+		log  func(note string, data ...any)
+	}{
+		{"Debug", Debug},
+		{"Info", Info},
+		{"Warn", Warn},
+		{"Error", Error},
+	} {
+		t.Run(level.name, func(t *testing.T) {
+			lines := captureOutput(t, func() {
+				level.log("note", map[string]any{"nested": map[string]any{"foo": "bar"}})
+			})
+
+			if len(lines) != 1 {
+				t.Fatalf("expected exactly 1 line of output, got %d: %v", len(lines), lines)
+			}
+
+			var entry logEntry
+			if err := json.Unmarshal([]byte(lines[0]), &entry); err != nil {
+				t.Fatalf("output is not valid single-line JSON: %v\nline: %s", err, lines[0])
+			}
+		})
+	}
+}
+
+// Railway's structured-log parser requires a top-level "message" field.
+func TestLogIt_SetsMessage(t *testing.T) {
+	lines := captureOutput(t, func() {
+		Info("info note")
+	})
+
+	if len(lines) != 1 {
+		t.Fatalf("expected exactly 1 line of output, got %d: %v", len(lines), lines)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &raw); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+
+	if raw["message"] != "info note" {
+		t.Errorf(`"message" = %v, want %q`, raw["message"], "info note")
+	}
+}
+
+// Service lets a caller (e.g. booky-ark's apigwadapter) attribute a log line
+// to the upstream microservice that produced it, since many microservices'
+// handlers run inside one shared process.
+func TestLogIt_SetsService(t *testing.T) {
+	t.Cleanup(func() { Service = "" })
+	Service = "booky-athena"
+
+	lines := captureOutput(t, func() {
+		Info("info note")
+	})
+
+	if len(lines) != 1 {
+		t.Fatalf("expected exactly 1 line of output, got %d: %v", len(lines), lines)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &raw); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+
+	if raw["service"] != "booky-athena" {
+		t.Errorf(`"service" = %v, want %q`, raw["service"], "booky-athena")
+	}
+}
+
+// Print never runs in production, so it never reaches Railway/CloudWatch —
+// pretty-printing it for local terminal readability is safe.
+func TestPrint_PrettyPrintsLocallyOnly(t *testing.T) {
+	t.Run("pretty-prints outside production", func(t *testing.T) {
+		t.Setenv("APP_ENV", "development")
+
+		lines := captureOutput(t, func() {
+			Print("print note", map[string]any{"foo": "bar"})
+		})
+
+		if len(lines) <= 1 {
+			t.Fatalf("expected multi-line pretty-printed output, got %d line(s): %v", len(lines), lines)
+		}
+	})
+
+	t.Run("suppressed in production", func(t *testing.T) {
+		t.Setenv("APP_ENV", PRODUCTION_ENV)
+
+		lines := captureOutput(t, func() {
+			Print("print note")
+		})
+
+		if len(lines) != 0 {
+			t.Fatalf("expected no output in production, got: %v", lines)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- `Debug`/`Print` used to emit pretty-printed (multi-line) JSON via `json.MarshalIndent`, while every other level emitted single-line JSON via `json.Marshal`. Railway's structured-log parser requires one JSON object per line — multi-line entries got torn apart and fell back to unstructured ingestion, defaulted to `info`, breaking `@level:` filtering (e.g. `@level:debug` found nothing, `@level:info` flooded with fragments of `Debug` payload dumps).
- `Debug` now emits single-line JSON like every shipped level. `Print` is dev-only (suppressed whenever `APP_ENV=production`), never reaches Railway/CloudWatch, so it keeps pretty-printing for local terminal readability.
- Renamed `note` → `message` — Railway's structured parser requires that exact top-level key to recognize a line as structured.
- Added `Service` (package-level var, set by the caller before invoking a handler) so multi-service consumers like booky-ark can attribute a log line to the upstream microservice that produced it.

## Test plan
- [x] `go test ./logs/...` — all passing, including new regression tests for single-line JSON output, the `message` field, `Print`'s pretty-print/production-suppression behavior, and `Service`.
- [x] `go build`/`go vet` clean.

ENG-607

🤖 Generated with [Claude Code](https://claude.com/claude-code)