### PR TITLE
fix(logs): derive Service from the caller's stack instead of a shared var

### DIFF
--- a/logs/logs.go
+++ b/logs/logs.go
@@ -8,6 +8,8 @@ import (
 	"encoding/json"
 	"log"
 	"os"
+	"runtime"
+	"strings"
 	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -46,11 +48,6 @@ type logEntry struct {
 }
 
 var Request any
-
-// Service identifies which upstream microservice is logging, since booky-ark
-// bundles many microservices' handlers into one process. Set by the caller
-// (e.g. booky-ark's apigwadapter/eventadapter) before invoking a handler.
-var Service string
 
 // Production-only debugging. Suppressed outside production (APP_ENV != production).
 // Use for targeted diagnostics when investigating a live issue.
@@ -117,7 +114,7 @@ func logIt(level Level, message string, data ...any) {
 		le.Request = Request
 		le.Function = os.Getenv("AWS_LAMBDA_FUNCTION_NAME")
 		le.AppEnv = os.Getenv("APP_ENV")
-		le.Service = Service
+		le.Service = callerService()
 	}
 
 	l, err := jsonMarshal(le)
@@ -152,6 +149,55 @@ func logIt(level Level, message string, data ...any) {
 	}()
 
 	wg.Wait()
+}
+
+// packageImportPath is this package's own import path — used to walk past
+// its own frames in callerService.
+const packageImportPath = "github.com/scrambledeggs/booky-go-common/logs"
+
+// callerService identifies which upstream microservice logged this entry, by
+// walking the call stack to the first frame outside this package — i.e.
+// whichever service's code called Debug/Info/Warn/etc. It's derived fresh on
+// every call rather than read from a shared variable set by some other
+// caller, so it's correct under concurrent use: a process like booky-ark
+// bundles many microservices' handlers into one binary, and a package-level
+// "current service" variable would race across concurrently running
+// handlers/messages, potentially misattributing one service's log line to
+// another.
+func callerService() string {
+	var pcs [32]uintptr
+	n := runtime.Callers(1, pcs[:])
+	frames := runtime.CallersFrames(pcs[:n])
+
+	for {
+		frame, more := frames.Next()
+		if !strings.HasPrefix(frame.Function, packageImportPath+".") {
+			return serviceFromFuncName(frame.Function)
+		}
+		if !more {
+			return ""
+		}
+	}
+}
+
+// serviceFromFuncName derives a service name from a fully-qualified function
+// name (as returned by runtime.Frame.Function), e.g.
+// "github.com/scrambledeggs/booky-athena/functions/X/handler.Handler" -> "booky-athena".
+//
+// Most upstream services declare "module github.com/scrambledeggs/X" in
+// their own go.mod, so this returns X. A few declare a bare module name with
+// no scrambledeggs/ prefix at all (e.g. "module booky-freyja") — for those,
+// this falls back to the first path segment, which is already the whole
+// module name.
+func serviceFromFuncName(name string) string {
+	parts := strings.Split(name, "/")
+	for i, p := range parts {
+		if p == "scrambledeggs" && i+1 < len(parts) {
+			return parts[i+1]
+		}
+	}
+
+	return parts[0]
 }
 
 // Print is dev-only console output — pretty-printed for terminal readability.

--- a/logs/logs_test.go
+++ b/logs/logs_test.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -96,28 +97,51 @@ func TestLogIt_SetsMessage(t *testing.T) {
 	}
 }
 
-// Service lets a caller (e.g. booky-ark's apigwadapter) attribute a log line
-// to the upstream microservice that produced it, since many microservices'
-// handlers run inside one shared process.
-func TestLogIt_SetsService(t *testing.T) {
-	t.Cleanup(func() { Service = "" })
-	Service = "booky-athena"
+// serviceFromFuncName is pure string parsing — exercise both module-path
+// shapes upstream services actually use (confirmed by checking their go.mod
+// files directly): the github.com/scrambledeggs/X convention, and a bare
+// module name with no scrambledeggs/ prefix at all.
+func TestServiceFromFuncName(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"scrambledeggs prefix", "github.com/scrambledeggs/booky-athena/functions/GetCollectionByIDAdminV1/handler.Handler", "booky-athena"},
+		{"bare module", "booky-freyja/functions/NearbyVouchersV1/handler.Handler", "booky-freyja"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := serviceFromFuncName(c.in); got != c.want {
+				t.Errorf("got %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+// Regression for the data race a reviewer caught on the previous approach
+// (a package-level Service variable written by the caller before invoking a
+// handler): concurrent callers must not share any mutable state. This alone
+// doesn't prove correct attribution across two different real callers (that's
+// covered by TestInfo_AttributesServiceFromCaller in service_test.go), but it
+// is the exact failure mode `go test -race` caught — run with -race to verify.
+func TestLogIt_ConcurrentCallsDoNotRace(t *testing.T) {
+	const n = 50
 
 	lines := captureOutput(t, func() {
-		Info("info note")
+		var wg sync.WaitGroup
+		for i := 0; i < n; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				Info("concurrent note")
+			}()
+		}
+		wg.Wait()
 	})
 
-	if len(lines) != 1 {
-		t.Fatalf("expected exactly 1 line of output, got %d: %v", len(lines), lines)
-	}
-
-	var raw map[string]any
-	if err := json.Unmarshal([]byte(lines[0]), &raw); err != nil {
-		t.Fatalf("output is not valid JSON: %v", err)
-	}
-
-	if raw["service"] != "booky-athena" {
-		t.Errorf(`"service" = %v, want %q`, raw["service"], "booky-athena")
+	if len(lines) != n {
+		t.Fatalf("expected %d lines, got %d", n, len(lines))
 	}
 }
 

--- a/logs/service_test.go
+++ b/logs/service_test.go
@@ -1,0 +1,52 @@
+// Package logs_test (external, black-box) is required here rather than the
+// internal "package logs" test file: testservice imports logs, so an
+// internal test file importing testservice would be a cyclic import.
+package logs_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/scrambledeggs/booky-go-common/logs/testservice"
+)
+
+// End-to-end proof that callerService's stack walk correctly identifies a
+// real external caller (as opposed to the unit tests in logs_test.go, which
+// only exercise the pure string-parsing half of the derivation).
+func TestInfo_AttributesServiceFromCaller(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+
+	origStdout := os.Stdout
+	os.Stdout = w
+	log.SetOutput(w)
+
+	testservice.CallInfo("hello from testservice")
+
+	w.Close()
+	os.Stdout = origStdout
+	log.SetOutput(os.Stdout)
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("io.Copy: %v", err)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &raw); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput: %s", err, buf.String())
+	}
+
+	// testservice lives inside the booky-go-common repo itself, so the
+	// scrambledeggs-segment rule attributes it to the repo — the same
+	// outcome booky-ark's own inline (non-upstream-service) handlers get.
+	if raw["service"] != "booky-go-common" {
+		t.Errorf(`"service" = %v, want %q`, raw["service"], "booky-go-common")
+	}
+}

--- a/logs/testservice/caller.go
+++ b/logs/testservice/caller.go
@@ -1,0 +1,11 @@
+// Package testservice exists only so logs' tests have a real, separate
+// caller package to prove callerService correctly walks past logs' own
+// frames to find the actual external caller.
+package testservice
+
+import "github.com/scrambledeggs/booky-go-common/logs"
+
+// CallInfo calls logs.Info from outside the logs package.
+func CallInfo(note string) {
+	logs.Info(note)
+}


### PR DESCRIPTION
## Summary
Follow-up to #41, addressing review feedback on [booky-ark#126](https://github.com/scrambledeggs/booky-ark/pull/126).

- `Service` was previously a package-level variable, written by whichever caller was about to invoke a handler (e.g. booky-ark's `apigwadapter`/`eventadapter`, before `logs.Service` even existed as a public API here). In a process that serves many microservices concurrently (booky-ark's whole design), two callers writing that same variable at the same time can misattribute one service's log line to another — the reviewer verified this failing under `go test -race` on the previous branch.
- `logIt` now derives the service name itself, per call, by walking the call stack (`runtime.Callers`) to the first frame outside this package and parsing its import path (same scrambledeggs-segment-or-first-segment rule as before). No shared state, so there's nothing to race — callers don't need to set anything before invoking a handler at all.

## Test plan
- [x] `go test -race -v ./...` — all passing, including a new concurrency stress test (`TestLogIt_ConcurrentCallsDoNotRace`) and an end-to-end test from a real separate caller package (`TestInfo_AttributesServiceFromCaller`, via a new `logs/testservice` helper) proving the stack-walk correctly identifies an external caller.
- [x] Unit tests for the pure string-parsing half (`TestServiceFromFuncName`) covering both module-path shapes upstream services use.

ENG-607

🤖 Generated with [Claude Code](https://claude.com/claude-code)