### PR TITLE
feat(logs): derive function field from caller when not on real Lambda

### DIFF
--- a/logs/logs.go
+++ b/logs/logs.go
@@ -111,10 +111,18 @@ func logIt(level Level, message string, data ...any) {
 	}
 
 	if level != PRINT {
+		caller := callerFuncName()
+
 		le.Request = Request
 		le.Function = os.Getenv("AWS_LAMBDA_FUNCTION_NAME")
+		if le.Function == "" {
+			// Real AWS Lambda always sets this env var; BCP/booky-ark and
+			// local dev never do, so fall back to deriving it from the
+			// caller's own stack frame.
+			le.Function = handlerNameFromFuncName(caller)
+		}
 		le.AppEnv = os.Getenv("APP_ENV")
-		le.Service = callerService()
+		le.Service = serviceFromFuncName(caller)
 	}
 
 	l, err := jsonMarshal(le)
@@ -152,19 +160,21 @@ func logIt(level Level, message string, data ...any) {
 }
 
 // packageImportPath is this package's own import path — used to walk past
-// its own frames in callerService.
+// its own frames in callerFuncName.
 const packageImportPath = "github.com/scrambledeggs/booky-go-common/logs"
 
-// callerService identifies which upstream microservice logged this entry, by
-// walking the call stack to the first frame outside this package — i.e.
-// whichever service's code called Debug/Info/Warn/etc. It's derived fresh on
-// every call rather than read from a shared variable set by some other
-// caller, so it's correct under concurrent use: a process like booky-ark
-// bundles many microservices' handlers into one binary, and a package-level
-// "current service" variable would race across concurrently running
-// handlers/messages, potentially misattributing one service's log line to
-// another.
-func callerService() string {
+// callerFuncName identifies who logged this entry, by walking the call stack
+// to the first frame outside this package and returning its fully-qualified
+// Go function name — i.e. whichever function called Debug/Info/Warn/etc. Both
+// serviceFromFuncName and handlerNameFromFuncName parse this same string.
+//
+// It's derived fresh on every call rather than read from a shared variable
+// set by some other caller, so it's correct under concurrent use: a process
+// like booky-ark bundles many microservices' handlers into one binary, and a
+// package-level "current caller" variable would race across concurrently
+// running handlers/messages, potentially misattributing one service's log
+// line to another.
+func callerFuncName() string {
 	var pcs [32]uintptr
 	n := runtime.Callers(1, pcs[:])
 	frames := runtime.CallersFrames(pcs[:n])
@@ -172,7 +182,7 @@ func callerService() string {
 	for {
 		frame, more := frames.Next()
 		if !strings.HasPrefix(frame.Function, packageImportPath+".") {
-			return serviceFromFuncName(frame.Function)
+			return frame.Function
 		}
 		if !more {
 			return ""
@@ -198,6 +208,29 @@ func serviceFromFuncName(name string) string {
 	}
 
 	return parts[0]
+}
+
+// handlerNameFromFuncName derives the upstream Lambda function's logical
+// name from a fully-qualified function name, e.g.
+// "github.com/scrambledeggs/booky-locations/functions/ReverseGeocodeV1/handler.Handler" -> "ReverseGeocodeV1"
+// "booky-orders/functions/GetOrderV1/handler.(*service).Handle" -> "GetOrderV1"
+//
+// Every upstream handler's exported entry point lives in a package literally
+// named "handler" (the upstream contract this monorepo documents); the
+// directory containing that package is the function's logical name — this
+// mirrors what AWS_LAMBDA_FUNCTION_NAME holds in real AWS. Returns "" when
+// the caller doesn't match this shape (e.g. booky-ark's own inline routes).
+func handlerNameFromFuncName(name string) string {
+	parts := strings.Split(name, "/")
+	if len(parts) < 2 {
+		return ""
+	}
+
+	if !strings.HasPrefix(parts[len(parts)-1], "handler.") {
+		return ""
+	}
+
+	return parts[len(parts)-2]
 }
 
 // Print is dev-only console output — pretty-printed for terminal readability.

--- a/logs/logs_test.go
+++ b/logs/logs_test.go
@@ -119,6 +119,54 @@ func TestServiceFromFuncName(t *testing.T) {
 	}
 }
 
+// handlerNameFromFuncName is pure string parsing — exercise both real call
+// shapes upstream handlers actually use (confirmed against real service
+// code): a plain top-level Handler func, and a bound method value like
+// orders' New(pool).Handle. Also confirm it returns "" for shapes that don't
+// match the handler package convention at all (e.g. booky-ark's own inline
+// closures).
+func TestHandlerNameFromFuncName(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain Handler func", "github.com/scrambledeggs/booky-locations/functions/ReverseGeocodeV1/handler.Handler", "ReverseGeocodeV1"},
+		{"bound method value", "booky-orders/functions/GetOrderV1/handler.(*service).Handle", "GetOrderV1"},
+		{"non-handler closure", "github.com/scrambledeggs/booky-ark/cmd/web.main.func1", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := handlerNameFromFuncName(c.in); got != c.want {
+				t.Errorf("got %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+// Real AWS Lambda always sets AWS_LAMBDA_FUNCTION_NAME; that value must win
+// over the caller-derived name so behavior there is unchanged.
+func TestLogIt_FunctionPrefersLambdaEnvVar(t *testing.T) {
+	t.Setenv("AWS_LAMBDA_FUNCTION_NAME", "real-lambda-name")
+
+	lines := captureOutput(t, func() {
+		Info("info note")
+	})
+
+	if len(lines) != 1 {
+		t.Fatalf("expected exactly 1 line of output, got %d: %v", len(lines), lines)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &raw); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+
+	if raw["function"] != "real-lambda-name" {
+		t.Errorf(`"function" = %v, want %q`, raw["function"], "real-lambda-name")
+	}
+}
+
 // Regression for the data race a reviewer caught on the previous approach
 // (a package-level Service variable written by the caller before invoking a
 // handler): concurrent callers must not share any mutable state. This alone


### PR DESCRIPTION
## Summary
Follow-up to #41/#42 (ENG-607). On Railway, `request.function` was always empty — it's populated from `AWS_LAMBDA_FUNCTION_NAME`, which real AWS Lambda always sets but BCP/booky-ark (and local dev) never do, since nothing there runs as an actual Lambda.

`logIt` now falls back to deriving it from the caller's own stack frame when that env var is unset, reusing the same call-stack walk already built for `Service`. Confirmed across real handler code in `booky-locations`, `booky-orders`, `booky-freyja`, and `booky-alberta` (different directory conventions — `functions/` vs `handlers/` — and different invocation shapes — plain functions vs bound method values like `New(pool).Handle`) that every upstream handler's exported entry point lives in a package literally named `handler`, so the directory containing that package is reliably the function's logical name:

- `.../booky-locations/functions/ReverseGeocodeV1/handler.Handler` → `ReverseGeocodeV1`
- `.../booky-orders/functions/GetOrderV1/handler.(*service).Handle` → `GetOrderV1`

Real AWS deployments are completely unaffected — `AWS_LAMBDA_FUNCTION_NAME` still wins whenever it's set; this only fills in the previously-always-empty case.

## Test plan
- [x] `go test -race -v ./...` — all passing, including new unit tests for both real call shapes (plain function, bound method) and confirming it returns `""` for shapes that don't match the handler convention (e.g. booky-ark's own inline closures), plus a test confirming the Lambda env var takes precedence when set.

ENG-607

🤖 Generated with [Claude Code](https://claude.com/claude-code)